### PR TITLE
Get Apache packages from archive.apache.org instead of mirror

### DIFF
--- a/2.7/install.sh
+++ b/2.7/install.sh
@@ -27,7 +27,7 @@ set -eo pipefail
 
 # Ensure we have an up to date package index.
 
-rm -r /var/lib/apt/lists/* 
+rm -rf /var/lib/apt/lists/*
 
 apt-get update
 

--- a/2.7/setup.sh
+++ b/2.7/setup.sh
@@ -86,19 +86,19 @@ mkdir $BUILD_ROOT/nghttp2
 
 tar -xC $BUILD_ROOT/nghttp2 --strip-components=1 -f $BUILD_ROOT/nghttp2.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-$APR_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr.tar.gz https://archive.apache.org/dist/apr/apr-$APR_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr
 
 tar -xC $BUILD_ROOT/apr --strip-components=1 -f $BUILD_ROOT/apr.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr-util.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-util-$APR_UTIL_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr-util.tar.gz https://archive.apache.org/dist/apr/apr-util-$APR_UTIL_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr-util
 
 tar -xC $BUILD_ROOT/apr-util --strip-components=1 -f $BUILD_ROOT/apr-util.tar.gz
 
-curl -SL -o $BUILD_ROOT/apache.tar.gz http://mirror.ventraip.net.au/apache/httpd/httpd-$APACHE_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apache.tar.gz https://archive.apache.org/dist/httpd/httpd-$APACHE_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apache
 

--- a/3.3/install.sh
+++ b/3.3/install.sh
@@ -27,7 +27,7 @@ set -eo pipefail
 
 # Ensure we have an up to date package index.
 
-rm -r /var/lib/apt/lists/* 
+rm -rf /var/lib/apt/lists/*
 
 apt-get update
 

--- a/3.3/setup.sh
+++ b/3.3/setup.sh
@@ -86,19 +86,19 @@ mkdir $BUILD_ROOT/nghttp2
 
 tar -xC $BUILD_ROOT/nghttp2 --strip-components=1 -f $BUILD_ROOT/nghttp2.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-$APR_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr.tar.gz https://archive.apache.org/dist/apr/apr-$APR_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr
 
 tar -xC $BUILD_ROOT/apr --strip-components=1 -f $BUILD_ROOT/apr.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr-util.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-util-$APR_UTIL_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr-util.tar.gz https://archive.apache.org/dist/apr/apr-util-$APR_UTIL_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr-util
 
 tar -xC $BUILD_ROOT/apr-util --strip-components=1 -f $BUILD_ROOT/apr-util.tar.gz
 
-curl -SL -o $BUILD_ROOT/apache.tar.gz http://mirror.ventraip.net.au/apache/httpd/httpd-$APACHE_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apache.tar.gz https://archive.apache.org/dist/httpd/httpd-$APACHE_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apache
 

--- a/3.4/install.sh
+++ b/3.4/install.sh
@@ -27,7 +27,7 @@ set -eo pipefail
 
 # Ensure we have an up to date package index.
 
-rm -r /var/lib/apt/lists/* 
+rm -rf /var/lib/apt/lists/*
 
 apt-get update
 

--- a/3.4/setup.sh
+++ b/3.4/setup.sh
@@ -86,19 +86,19 @@ mkdir $BUILD_ROOT/nghttp2
 
 tar -xC $BUILD_ROOT/nghttp2 --strip-components=1 -f $BUILD_ROOT/nghttp2.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-$APR_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr.tar.gz https://archive.apache.org/dist/apr/apr-$APR_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr
 
 tar -xC $BUILD_ROOT/apr --strip-components=1 -f $BUILD_ROOT/apr.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr-util.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-util-$APR_UTIL_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr-util.tar.gz https://archive.apache.org/dist/apr/apr-util-$APR_UTIL_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr-util
 
 tar -xC $BUILD_ROOT/apr-util --strip-components=1 -f $BUILD_ROOT/apr-util.tar.gz
 
-curl -SL -o $BUILD_ROOT/apache.tar.gz http://mirror.ventraip.net.au/apache/httpd/httpd-$APACHE_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apache.tar.gz https://archive.apache.org/dist/httpd/httpd-$APACHE_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apache
 

--- a/3.5/install.sh
+++ b/3.5/install.sh
@@ -27,7 +27,7 @@ set -eo pipefail
 
 # Ensure we have an up to date package index.
 
-rm -r /var/lib/apt/lists/* 
+rm -rf /var/lib/apt/lists/*
 
 apt-get update
 

--- a/3.5/setup.sh
+++ b/3.5/setup.sh
@@ -86,19 +86,19 @@ mkdir $BUILD_ROOT/nghttp2
 
 tar -xC $BUILD_ROOT/nghttp2 --strip-components=1 -f $BUILD_ROOT/nghttp2.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-$APR_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr.tar.gz https://archive.apache.org/dist/apr/apr-$APR_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr
 
 tar -xC $BUILD_ROOT/apr --strip-components=1 -f $BUILD_ROOT/apr.tar.gz
 
-curl -SL -o $BUILD_ROOT/apr-util.tar.gz http://mirror.ventraip.net.au/apache/apr/apr-util-$APR_UTIL_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apr-util.tar.gz https://archive.apache.org/dist/apr/apr-util-$APR_UTIL_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apr-util
 
 tar -xC $BUILD_ROOT/apr-util --strip-components=1 -f $BUILD_ROOT/apr-util.tar.gz
 
-curl -SL -o $BUILD_ROOT/apache.tar.gz http://mirror.ventraip.net.au/apache/httpd/httpd-$APACHE_VERSION.tar.gz
+curl -SL -o $BUILD_ROOT/apache.tar.gz https://archive.apache.org/dist/httpd/httpd-$APACHE_VERSION.tar.gz
 
 mkdir $BUILD_ROOT/apache
 


### PR DESCRIPTION
While building an image on top of this using some of the defined environment variables (`APR_UTIL_VERSION`, etc.), I noticed that the mirror.ventraip.net.au links for the pinned versions are no longer valid, since the mirror only has the latest version.

Hence, I changed the links to point to archive.apache.org which should (hopefully) be stable for much longer.

Also, the images wouldn't build from scratch from the current `master`, because the `rm` for `/var/lib/apt/lists` was failing out with a "No such file or directory." I added a `-f` to fix that.

**Testing:** Images built without errors from the `build.sh` script.

